### PR TITLE
remove builder pattern for leader election due to unexported struct

### DIFF
--- a/leaderelection/leader_election.go
+++ b/leaderelection/leader_election.go
@@ -107,29 +107,24 @@ func NewLeaderElectionWithConfigMaps(clientset kubernetes.Interface, lockName st
 	}
 }
 
-func (l *leaderElection) WithIdentity(identity string) *leaderElection {
+func (l *leaderElection) WithIdentity(identity string) {
 	l.identity = identity
-	return l
 }
 
-func (l *leaderElection) WithNamespace(namespace string) *leaderElection {
+func (l *leaderElection) WithNamespace(namespace string) {
 	l.namespace = namespace
-	return l
 }
 
-func (l *leaderElection) WithLeaseDuration(leaseDuration time.Duration) *leaderElection {
+func (l *leaderElection) WithLeaseDuration(leaseDuration time.Duration) {
 	l.leaseDuration = leaseDuration
-	return l
 }
 
-func (l *leaderElection) WithRenewDeadline(renewDeadline time.Duration) *leaderElection {
+func (l *leaderElection) WithRenewDeadline(renewDeadline time.Duration) {
 	l.renewDeadline = renewDeadline
-	return l
 }
 
-func (l *leaderElection) WithRetryPeriod(retryPeriod time.Duration) *leaderElection {
+func (l *leaderElection) WithRetryPeriod(retryPeriod time.Duration) {
 	l.retryPeriod = retryPeriod
-	return l
 }
 
 func (l *leaderElection) Run() error {


### PR DESCRIPTION
Removing the builder pattern in the leaderelection package since it doesn't make it very friendly for external use without exporting the leaderElection struct which I prefer not to do.