### PR TITLE
Remove duplicate code in connection package

### DIFF
--- a/connection/connection.go
+++ b/connection/connection.go
@@ -19,16 +19,11 @@ package connection
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"net"
 	"strings"
 	"time"
 
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-
-	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/kubernetes-csi/csi-lib-utils/protosanitizer"
 	"google.golang.org/grpc"
 	"k8s.io/klog"
@@ -183,128 +178,4 @@ func LogGRPC(ctx context.Context, method string, req, reply interface{}, cc *grp
 	klog.V(5).Infof("GRPC response: %s", protosanitizer.StripSecrets(reply))
 	klog.V(5).Infof("GRPC error: %v", err)
 	return err
-}
-
-// GetDriverName returns name of CSI driver.
-func GetDriverName(ctx context.Context, conn *grpc.ClientConn) (string, error) {
-	client := csi.NewIdentityClient(conn)
-
-	req := csi.GetPluginInfoRequest{}
-	rsp, err := client.GetPluginInfo(ctx, &req)
-	if err != nil {
-		return "", err
-	}
-	name := rsp.GetName()
-	if name == "" {
-		return "", fmt.Errorf("driver name is empty")
-	}
-	return name, nil
-}
-
-// PluginCapabilitySet is set of CSI plugin capabilities. Only supported capabilities are in the map.
-type PluginCapabilitySet map[csi.PluginCapability_Service_Type]bool
-
-// GetPluginCapabilities returns set of supported capabilities of CSI driver.
-func GetPluginCapabilities(ctx context.Context, conn *grpc.ClientConn) (PluginCapabilitySet, error) {
-	client := csi.NewIdentityClient(conn)
-	req := csi.GetPluginCapabilitiesRequest{}
-	rsp, err := client.GetPluginCapabilities(ctx, &req)
-	if err != nil {
-		return nil, err
-	}
-	caps := PluginCapabilitySet{}
-	for _, cap := range rsp.GetCapabilities() {
-		if cap == nil {
-			continue
-		}
-		srv := cap.GetService()
-		if srv == nil {
-			continue
-		}
-		t := srv.GetType()
-		caps[t] = true
-	}
-	return caps, nil
-}
-
-// ControllerCapabilitySet is set of CSI controller capabilities. Only supported capabilities are in the map.
-type ControllerCapabilitySet map[csi.ControllerServiceCapability_RPC_Type]bool
-
-// GetControllerCapabilities returns set of supported controller capabilities of CSI driver.
-func GetControllerCapabilities(ctx context.Context, conn *grpc.ClientConn) (ControllerCapabilitySet, error) {
-	client := csi.NewControllerClient(conn)
-	req := csi.ControllerGetCapabilitiesRequest{}
-	rsp, err := client.ControllerGetCapabilities(ctx, &req)
-	if err != nil {
-		return nil, err
-	}
-
-	caps := ControllerCapabilitySet{}
-	for _, cap := range rsp.GetCapabilities() {
-		if cap == nil {
-			continue
-		}
-		rpc := cap.GetRpc()
-		if rpc == nil {
-			continue
-		}
-		t := rpc.GetType()
-		caps[t] = true
-	}
-	return caps, nil
-}
-
-// ProbeForever calls Probe() of a CSI driver and waits until the driver becomes ready.
-// Any error other than timeout is returned.
-func ProbeForever(conn *grpc.ClientConn, singleProbeTimeout time.Duration) error {
-	for {
-		klog.Info("Probing CSI driver for readiness")
-		ready, err := probeOnce(conn, singleProbeTimeout)
-		if err != nil {
-			st, ok := status.FromError(err)
-			if !ok {
-				// This is not gRPC error. The probe must have failed before gRPC
-				// method was called, otherwise we would get gRPC error.
-				return fmt.Errorf("CSI driver probe failed: %s", err)
-			}
-			if st.Code() != codes.DeadlineExceeded {
-				return fmt.Errorf("CSI driver probe failed: %s", err)
-			}
-			// Timeout -> driver is not ready. Fall through to sleep() below.
-			klog.Warning("CSI driver probe timed out")
-		} else {
-			if ready {
-				return nil
-			}
-			klog.Warning("CSI driver is not ready")
-		}
-		// Timeout was returned or driver is not ready.
-		time.Sleep(probeInterval)
-	}
-}
-
-// probeOnce is a helper to simplify defer cancel()
-func probeOnce(conn *grpc.ClientConn, timeout time.Duration) (bool, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-	return Probe(ctx, conn)
-}
-
-// Probe calls driver Probe() just once and returns its result without any processing.
-func Probe(ctx context.Context, conn *grpc.ClientConn) (ready bool, err error) {
-	client := csi.NewIdentityClient(conn)
-
-	req := csi.ProbeRequest{}
-	rsp, err := client.Probe(ctx, &req)
-
-	if err != nil {
-		return false, err
-	}
-
-	r := rsp.GetReady()
-	if r == nil {
-		// "If not present, the caller SHALL assume that the plugin is in a ready state"
-		return true, nil
-	}
-	return r.GetValue(), nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
 kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
There are duplicate functions present in both rpc and connection package. This PR removes the duplicate code from connection package.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #30 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The rpc and connection package has the same code, removed duplicate code from connection package. connection package will have the code related to RPC connection
```
