### PR TITLE
metrics: support usage inside CSI driver

### DIFF
--- a/connection/connection.go
+++ b/connection/connection.go
@@ -109,7 +109,7 @@ func connect(
 		grpc.WithBlock(),                      // Block until connection succeeds.
 		grpc.WithChainUnaryInterceptor(
 			LogGRPC, // Log all messages.
-			extendedCSIMetricsManager{metricsManager}.recordMetricsInterceptor, // Record metrics for each gRPC call.
+			ExtendedCSIMetricsManager{metricsManager}.RecordMetricsClientInterceptor, // Record metrics for each gRPC call.
 		),
 	)
 	unixPrefix := "unix://"
@@ -187,12 +187,13 @@ func LogGRPC(ctx context.Context, method string, req, reply interface{}, cc *grp
 	return err
 }
 
-type extendedCSIMetricsManager struct {
+type ExtendedCSIMetricsManager struct {
 	metrics.CSIMetricsManager
 }
 
-// recordMetricsInterceptor is a gPRC unary interceptor for recording metrics for CSI operations.
-func (cmm extendedCSIMetricsManager) recordMetricsInterceptor(
+// RecordMetricsClientInterceptor is a gPRC unary interceptor for recording metrics for CSI operations
+// in a gRPC client.
+func (cmm ExtendedCSIMetricsManager) RecordMetricsClientInterceptor(
 	ctx context.Context,
 	method string,
 	req, reply interface{},
@@ -208,4 +209,18 @@ func (cmm extendedCSIMetricsManager) recordMetricsInterceptor(
 		duration, /* operationDuration */
 	)
 	return err
+}
+
+// RecordMetricsServerInterceptor is a gPRC unary interceptor for recording metrics for CSI operations
+// in a gRCP server.
+func (cmm ExtendedCSIMetricsManager) RecordMetricsServerInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	start := time.Now()
+	resp, err := handler(ctx, req)
+	duration := time.Since(start)
+	cmm.RecordMetrics(
+		info.FullMethod, /* operationName */
+		err,             /* operationErr */
+		duration,        /* operationDuration */
+	)
+	return resp, err
 }

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -107,7 +107,10 @@ func WithSubsystem(subsystem string) MetricsManagerOption {
 	}
 }
 
-// WithStabilityLevel overrides the default stability level.
+// WithStabilityLevel overrides the default stability level. The recommended
+// usage is to keep metrics at a lower level when csi-lib-utils switches
+// to beta or GA. Overriding the alpha default with beta or GA is risky
+// because the metrics can still change in the library.
 func WithStabilityLevel(stabilityLevel metrics.StabilityLevel) MetricsManagerOption {
 	return func(cmm *csiMetricsManager) {
 		cmm.stabilityLevel = stabilityLevel

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -335,7 +335,7 @@ func TestVaryingLabels_NameError(t *testing.T) {
 	}
 }
 
-func TestVaryingLabels_NumberError(t *testing.T) {
+func TestVaryingLabels_OverwriteError(t *testing.T) {
 	cmm := NewCSIMetricsManagerWithOptions(
 		"", /* driverName */
 		WithLabelNames("a", "b"),


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

A CSI driver is a gRPC server, which implies that the interceptor must
use a slightly different API. The extended CSIMetricsManager gets
exported with a suitable method for that.

To avoid counting the same operation twice in the same metric, CSI
sidecar and driver should use different subsystem names. CSI driver
authors may decide to declare metrics support as "stable" based on
other criteria than the Kubernetes-CSI sidecars. Both aspects are now
configurable.

**Special notes for your reviewer**:

These API changes are backwards-compatible.

**Does this PR introduce a user-facing change?**:
```release-note
metrics support can also be used by CSI drivers
```
