### PR TITLE
Add process_start_time_seconds metric into csi metric lib

### DIFF
--- a/connection/connection_test.go
+++ b/connection/connection_test.go
@@ -383,7 +383,7 @@ func TestConnectMetrics(t *testing.T) {
 	`
 
 	if err := testutil.GatherAndCompare(
-		cmm.GetRegistry(), strings.NewReader(expectedMetrics)); err != nil {
+		cmm.GetRegistry(), strings.NewReader(expectedMetrics), "csi_sidecar_operations_seconds"); err != nil {
 		// Ignore mismatches on csi_sidecar_operations_seconds_sum metric because execution time will vary from test to test.
 		err = verifyMetricsError(t, err, "csi_sidecar_operations_seconds_sum")
 		if err != nil {
@@ -393,7 +393,7 @@ func TestConnectMetrics(t *testing.T) {
 
 	expectedMetrics = strings.Replace(expectedMetrics, "csi_sidecar", metrics.SubsystemPlugin, -1)
 	if err := testutil.GatherAndCompare(
-		cmmServer.GetRegistry(), strings.NewReader(expectedMetrics)); err != nil {
+		cmmServer.GetRegistry(), strings.NewReader(expectedMetrics), "csi_plugin_operations_seconds"); err != nil {
 		// Ignore mismatches on csi_sidecar_operations_seconds_sum metric because execution time will vary from test to test.
 		err = verifyMetricsError(t, err, metrics.SubsystemPlugin+"_operations_seconds_sum")
 		if err != nil {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -181,6 +181,11 @@ func NewCSIMetricsManagerWithOptions(driverName string, options ...MetricsManage
 		subsystem:      SubsystemSidecar,
 		stabilityLevel: metrics.ALPHA,
 	}
+
+	// https://github.com/open-telemetry/opentelemetry-collector/issues/969
+	// Add process_start_time_seconds into the metric to let the start time be parsed correctly
+	metrics.RegisterProcessStartTime(cmm.registry.Register)
+
 	for _, option := range options {
 		option(&cmm)
 	}
@@ -357,7 +362,11 @@ func VerifyMetricsMatch(expectedMetrics, actualMetrics string, metricToIgnore st
 		wantScanner.Scan()
 		wantLine := strings.TrimSpace(wantScanner.Text())
 		gotLine := strings.TrimSpace(gotScanner.Text())
-		if wantLine != gotLine && (metricToIgnore == "" || !strings.HasPrefix(gotLine, metricToIgnore)) {
+		if wantLine != gotLine &&
+			(metricToIgnore == "" || !strings.HasPrefix(gotLine, metricToIgnore)) &&
+			// We should ignore the comments from metricToIgnore, otherwise the verification will
+			// fail because of the comments.
+			!strings.HasPrefix(gotLine, "#") {
 			return fmt.Errorf("\r\nMetric Want: %q\r\nMetric Got:  %q\r\n", wantLine, gotLine)
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:
This PR adds the process_start_time_seconds metric into the csi metric lib.

**Does this PR introduce a user-facing change?**:
```release-note
Add `process_start_time_seconds` into the csi metric lib.
```
