### PR TITLE
[Cherry-pick]Add process_start_time_seconds metric into csi metric lib

### DIFF
--- a/connection/connection_test.go
+++ b/connection/connection_test.go
@@ -359,7 +359,7 @@ func TestConnectMetrics(t *testing.T) {
 	`
 
 	if err := testutil.GatherAndCompare(
-		cmm.GetRegistry(), strings.NewReader(expectedMetrics)); err != nil {
+		cmm.GetRegistry(), strings.NewReader(expectedMetrics), "csi_sidecar_operations_seconds"); err != nil {
 		// Ignore mismatches on csi_sidecar_operations_seconds_sum metric because execution time will vary from test to test.
 		err = verifyMetricsError(t, err, "csi_sidecar_operations_seconds_sum")
 		if err != nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
This PR adds the process_start_time_seconds metric into the csi metric lib.

**Does this PR introduce a user-facing change?**:
```release-note
Add `process_start_time_seconds` into the csi metric lib.
```
Cherry pick from: https://github.com/kubernetes-csi/csi-lib-utils/pull/54