### PR TITLE
master: update release-tools

### DIFF
--- a/release-tools/build.make
+++ b/release-tools/build.make
@@ -69,12 +69,17 @@ endif
 # toolchain.
 BUILD_PLATFORMS =
 
+# Add go ldflags using LDFLAGS at the time of compilation.
+IMPORTPATH_LDFLAGS = -X main.version=$(REV) 
+EXT_LDFLAGS = -extldflags "-static"
+LDFLAGS = 
+FULL_LDFLAGS = $(LDFLAGS) $(IMPORTPATH_LDFLAGS) $(EXT_LDFLAGS)
 # This builds each command (= the sub-directories of ./cmd) for the target platform(s)
 # defined by BUILD_PLATFORMS.
 $(CMDS:%=build-%): build-%: check-go-version-go
 	mkdir -p bin
 	echo '$(BUILD_PLATFORMS)' | tr ';' '\n' | while read -r os arch suffix; do \
-		if ! (set -x; CGO_ENABLED=0 GOOS="$$os" GOARCH="$$arch" go build $(GOFLAGS_VENDOR) -a -ldflags '-X main.version=$(REV) -extldflags "-static"' -o "./bin/$*$$suffix" ./cmd/$*); then \
+		if ! (set -x; CGO_ENABLED=0 GOOS="$$os" GOARCH="$$arch" go build $(GOFLAGS_VENDOR) -a -ldflags '$(FULL_LDFLAGS)' -o "./bin/$*$$suffix" ./cmd/$*); then \
 			echo "Building $* for GOOS=$$os GOARCH=$$arch failed, see error(s) above."; \
 			exit 1; \
 		fi; \


### PR DESCRIPTION
Squashed 'release-tools/' changes from 3041b8a..4aff857

[4aff857](https://github.com/kubernetes-csi/csi-release-tools/commit/4aff857) Merge pull request #109 from pohly/alpha-test-defaults
[0427289](https://github.com/kubernetes-csi/csi-release-tools/commit/0427289) Merge pull request #110 from pohly/kind-0.9-bazel-build-workaround
[9a370ab](https://github.com/kubernetes-csi/csi-release-tools/commit/9a370ab) prow.sh: work around "kind build node-image" failure
[522361e](https://github.com/kubernetes-csi/csi-release-tools/commit/522361e) prow.sh: only run alpha tests for latest Kubernetes release
[22c0395](https://github.com/kubernetes-csi/csi-release-tools/commit/22c0395) Merge pull request #108 from bnrjee/master
[b5b447b](https://github.com/kubernetes-csi/csi-release-tools/commit/b5b447b) Add go ldflags using LDFLAGS at the time of compilation
[16f4afb](https://github.com/kubernetes-csi/csi-release-tools/commit/16f4afb) Merge pull request #107 from pohly/kind-update
[7bcee13](https://github.com/kubernetes-csi/csi-release-tools/commit/7bcee13) prow.sh: update to kind 0.9, support Kubernetes 1.19
[df518fb](https://github.com/kubernetes-csi/csi-release-tools/commit/df518fb) prow.sh: usage of Bazel optional
[c3afd42](https://github.com/kubernetes-csi/csi-release-tools/commit/c3afd42) Merge pull request #104 from xing-yang/snapshot
[dde93b2](https://github.com/kubernetes-csi/csi-release-tools/commit/dde93b2) Update to snapshot-controller v3.0.0
[a0f195c](https://github.com/kubernetes-csi/csi-release-tools/commit/a0f195c) Merge pull request #106 from msau42/fix-canary
[7100c12](https://github.com/kubernetes-csi/csi-release-tools/commit/7100c12) Only set staging registry when running canary job
[b3c65f9](https://github.com/kubernetes-csi/csi-release-tools/commit/b3c65f9) Merge pull request #99 from msau42/add-release-process
[e53f3e8](https://github.com/kubernetes-csi/csi-release-tools/commit/e53f3e8) Merge pull request #103 from msau42/fix-canary
[d129462](https://github.com/kubernetes-csi/csi-release-tools/commit/d129462) Document new method for adding CI jobs are new K8s versions
[e73c2ce](https://github.com/kubernetes-csi/csi-release-tools/commit/e73c2ce) Use staging registry for canary tests
[2c09846](https://github.com/kubernetes-csi/csi-release-tools/commit/2c09846) Add cleanup instructions to release-notes generation
[60e1cd3](https://github.com/kubernetes-csi/csi-release-tools/commit/60e1cd3) Merge pull request #98 from pohly/kubernetes-1-19-fixes
[0979c09](https://github.com/kubernetes-csi/csi-release-tools/commit/0979c09) prow.sh: fix E2E suite for Kubernetes >= 1.18
[3b4a2f1](https://github.com/kubernetes-csi/csi-release-tools/commit/3b4a2f1) prow.sh: fix installing Go for Kubernetes 1.19.0
[1fbb636](https://github.com/kubernetes-csi/csi-release-tools/commit/1fbb636) Merge pull request #97 from pohly/go-1.15
[82d108a](https://github.com/kubernetes-csi/csi-release-tools/commit/82d108a) switch to Go 1.15
[d8a2530](https://github.com/kubernetes-csi/csi-release-tools/commit/d8a2530) Merge pull request #95 from msau42/add-release-process
[843bddc](https://github.com/kubernetes-csi/csi-release-tools/commit/843bddc) Add steps on promoting release images
[0345a83](https://github.com/kubernetes-csi/csi-release-tools/commit/0345a83) Merge pull request #94 from linux-on-ibm-z/bump-timeout
[1fdf2d5](https://github.com/kubernetes-csi/csi-release-tools/commit/1fdf2d5) cloud build: bump timeout in Prow job
[41ec6d1](https://github.com/kubernetes-csi/csi-release-tools/commit/41ec6d1) Merge pull request #93 from animeshk08/patch-1
[5a54e67](https://github.com/kubernetes-csi/csi-release-tools/commit/5a54e67) filter-junit: Fix gofmt error
[0676fcb](https://github.com/kubernetes-csi/csi-release-tools/commit/0676fcb) Merge pull request #92 from animeshk08/patch-1
[36ea4ff](https://github.com/kubernetes-csi/csi-release-tools/commit/36ea4ff) filter-junit: Fix golint error
[f5a4203](https://github.com/kubernetes-csi/csi-release-tools/commit/f5a4203) Merge pull request #91 from cyb70289/arm64
[43e50d6](https://github.com/kubernetes-csi/csi-release-tools/commit/43e50d6) prow.sh: enable building arm64 image
[0d5bd84](https://github.com/kubernetes-csi/csi-release-tools/commit/0d5bd84) Merge pull request #90 from pohly/k8s-staging-sig-storage
[3df86b7](https://github.com/kubernetes-csi/csi-release-tools/commit/3df86b7) cloud build: k8s-staging-sig-storage
[c5fd961](https://github.com/kubernetes-csi/csi-release-tools/commit/c5fd961) Merge pull request #89 from pohly/cloud-build-binfmt
[db0c2a7](https://github.com/kubernetes-csi/csi-release-tools/commit/db0c2a7) cloud build: initialize support for running commands in Dockerfile
[be902f4](https://github.com/kubernetes-csi/csi-release-tools/commit/be902f4) Merge pull request #88 from pohly/multiarch-windows-fix
[340e082](https://github.com/kubernetes-csi/csi-release-tools/commit/340e082) build.make: optional inclusion of Windows in multiarch images
[5231f05](https://github.com/kubernetes-csi/csi-release-tools/commit/5231f05) build.make: properly declare push-multiarch
[4569f27](https://github.com/kubernetes-csi/csi-release-tools/commit/4569f27) build.make: fix push-multiarch ambiguity
[17dde9e](https://github.com/kubernetes-csi/csi-release-tools/commit/17dde9e) Merge pull request #87 from pohly/cloud-build
[bd41690](https://github.com/kubernetes-csi/csi-release-tools/commit/bd41690) cloud build: initial set of shared files
[9084fec](https://github.com/kubernetes-csi/csi-release-tools/commit/9084fec) Merge pull request #81 from msau42/add-release-process
[6f2322e](https://github.com/kubernetes-csi/csi-release-tools/commit/6f2322e) Update patch release notes generation command
[0fcc3b1](https://github.com/kubernetes-csi/csi-release-tools/commit/0fcc3b1) Merge pull request #78 from ggriffiths/fix_csi_snapshotter_rbac_version_set
[d8c76fe](https://github.com/kubernetes-csi/csi-release-tools/commit/d8c76fe) Support local snapshot RBAC for pull jobs
[c1bdf5b](https://github.com/kubernetes-csi/csi-release-tools/commit/c1bdf5b) Merge pull request #80 from msau42/add-release-process
[ea1f94a](https://github.com/kubernetes-csi/csi-release-tools/commit/ea1f94a) update release tools instructions
[152396e](https://github.com/kubernetes-csi/csi-release-tools/commit/152396e) Merge pull request #77 from ggriffiths/snapshotter201_update
[7edc146](https://github.com/kubernetes-csi/csi-release-tools/commit/7edc146) Update snapshotter to version 2.0.1
[4cf843f](https://github.com/kubernetes-csi/csi-release-tools/commit/4cf843f) Merge pull request #76 from pohly/build-targets
[3863a0f](https://github.com/kubernetes-csi/csi-release-tools/commit/3863a0f) build for multiple platforms only in CI, add s390x
[8322a7d](https://github.com/kubernetes-csi/csi-release-tools/commit/8322a7d) Merge pull request #72 from pohly/hostpath-update
[7c5a89c](https://github.com/kubernetes-csi/csi-release-tools/commit/7c5a89c) prow.sh: use 1.3.0 hostpath driver for testing
[b8587b2](https://github.com/kubernetes-csi/csi-release-tools/commit/b8587b2) Merge pull request #71 from wozniakjan/test-vet
[fdb3218](https://github.com/kubernetes-csi/csi-release-tools/commit/fdb3218) Change 'make test-vet' to call 'go vet'
[d717c8c](https://github.com/kubernetes-csi/csi-release-tools/commit/d717c8c) Merge pull request #69 from pohly/test-driver-config
[a1432bc](https://github.com/kubernetes-csi/csi-release-tools/commit/a1432bc) Merge pull request #70 from pohly/kubelet-feature-gates
[5f74333](https://github.com/kubernetes-csi/csi-release-tools/commit/5f74333) prow.sh: also configure feature gates for kubelet
[84f78b1](https://github.com/kubernetes-csi/csi-release-tools/commit/84f78b1) prow.sh: generic driver installation
[3c34b4f](https://github.com/kubernetes-csi/csi-release-tools/commit/3c34b4f) Merge pull request #67 from windayski/fix-link
[fa90abd](https://github.com/kubernetes-csi/csi-release-tools/commit/fa90abd) fix incorrect link
[ff3cc3f](https://github.com/kubernetes-csi/csi-release-tools/commit/ff3cc3f) Merge pull request #54 from msau42/add-release-process
[ac8a021](https://github.com/kubernetes-csi/csi-release-tools/commit/ac8a021) Document the process for releasing a new sidecar
[23be652](https://github.com/kubernetes-csi/csi-release-tools/commit/23be652) Merge pull request #65 from msau42/update-hostpath
[6582f2f](https://github.com/kubernetes-csi/csi-release-tools/commit/6582f2f) Update hostpath driver version to get fix for connection-timeout
[4cc9174](https://github.com/kubernetes-csi/csi-release-tools/commit/4cc9174) Merge pull request #64 from ggriffiths/snapshotter_2_version_update
[8191eab](https://github.com/kubernetes-csi/csi-release-tools/commit/8191eab) Update snapshotter to version v2.0.0
[3c463fb](https://github.com/kubernetes-csi/csi-release-tools/commit/3c463fb) Merge pull request #61 from msau42/enable-snapshots
[8b0316c](https://github.com/kubernetes-csi/csi-release-tools/commit/8b0316c) Fix overriding of junit results by using unique names for each e2e run
[5f444b8](https://github.com/kubernetes-csi/csi-release-tools/commit/5f444b8) Merge pull request #60 from saad-ali/updateHostpathVersion
[af9549b](https://github.com/kubernetes-csi/csi-release-tools/commit/af9549b) Update prow hostpath driver version to 1.3.0-rc2
[f6c74b3](https://github.com/kubernetes-csi/csi-release-tools/commit/f6c74b3) Merge pull request #57 from ggriffiths/version_gt_kubernetes_fix
[fc80975](https://github.com/kubernetes-csi/csi-release-tools/commit/fc80975) Fix version_gt to work with kubernetes prefix
[9f1f3dd](https://github.com/kubernetes-csi/csi-release-tools/commit/9f1f3dd) Merge pull request #56 from msau42/enable-snapshots
[b98b2ae](https://github.com/kubernetes-csi/csi-release-tools/commit/b98b2ae) Enable snapshot tests in 1.17 to be run in non-alpha jobs.
[9ace020](https://github.com/kubernetes-csi/csi-release-tools/commit/9ace020) Merge pull request #52 from msau42/update-readme
[540599b](https://github.com/kubernetes-csi/csi-release-tools/commit/540599b) Merge pull request #53 from msau42/fix-make
[a4e6299](https://github.com/kubernetes-csi/csi-release-tools/commit/a4e6299) fix syntax for ppc64le build
[771ca6f](https://github.com/kubernetes-csi/csi-release-tools/commit/771ca6f) Merge pull request #49 from ggriffiths/prowsh_improve_version_gt
[d7c69d2](https://github.com/kubernetes-csi/csi-release-tools/commit/d7c69d2) Merge pull request #51 from msau42/enable-multinode
[4ad6949](https://github.com/kubernetes-csi/csi-release-tools/commit/4ad6949) Improve snapshot pod running checks and improve version_gt
[53888ae](https://github.com/kubernetes-csi/csi-release-tools/commit/53888ae) Improve README by adding an explicit Kubernetes dependency section
[9a7a685](https://github.com/kubernetes-csi/csi-release-tools/commit/9a7a685) Create a kind cluster with two worker nodes so that the topology feature can be tested. Test cases that test accessing volumes from multiple nodes need to be skipped
[4ff2f5f](https://github.com/kubernetes-csi/csi-release-tools/commit/4ff2f5f) Merge pull request #50 from darkowlzz/kind-0.6.0
[80bba1f](https://github.com/kubernetes-csi/csi-release-tools/commit/80bba1f) Use kind v0.6.0
[6d674a7](https://github.com/kubernetes-csi/csi-release-tools/commit/6d674a7) Merge pull request #47 from Pensu/multi-arch
[8adde49](https://github.com/kubernetes-csi/csi-release-tools/commit/8adde49) Merge pull request #45 from ggriffiths/snapshot_beta_crds
[003c14b](https://github.com/kubernetes-csi/csi-release-tools/commit/003c14b) Add snapshotter CRDs after cluster setup
[a41f386](https://github.com/kubernetes-csi/csi-release-tools/commit/a41f386) Merge pull request #46 from mucahitkurt/kind-cluster-cleanup
[1eaaaa1](https://github.com/kubernetes-csi/csi-release-tools/commit/1eaaaa1) Delete kind cluster after tests run.
[83a4ef1](https://github.com/kubernetes-csi/csi-release-tools/commit/83a4ef1) Adding build for ppc64le
[4fcafec](https://github.com/kubernetes-csi/csi-release-tools/commit/4fcafec) Merge pull request #43 from pohly/system-pod-logging
[f41c135](https://github.com/kubernetes-csi/csi-release-tools/commit/f41c135) prow.sh: also log output of system containers
[ee22a9c](https://github.com/kubernetes-csi/csi-release-tools/commit/ee22a9c) Merge pull request #42 from pohly/use-vendor-dir
[8067845](https://github.com/kubernetes-csi/csi-release-tools/commit/8067845) travis.yml: also use vendor directory
[23df4ae](https://github.com/kubernetes-csi/csi-release-tools/commit/23df4ae) prow.sh: use vendor directory if available
[a53bd4c](https://github.com/kubernetes-csi/csi-release-tools/commit/a53bd4c) Merge pull request #41 from pohly/go-version
[c8a1c4a](https://github.com/kubernetes-csi/csi-release-tools/commit/c8a1c4a) better handling of Go version
[5e773d2](https://github.com/kubernetes-csi/csi-release-tools/commit/5e773d2) update CI to use Go 1.13.3
[f419d74](https://github.com/kubernetes-csi/csi-release-tools/commit/f419d74) Merge pull request #40 from msau42/add-1.16
[e0fde8c](https://github.com/kubernetes-csi/csi-release-tools/commit/e0fde8c) Add new variables for 1.16 and remove 1.13
[adf00fe](https://github.com/kubernetes-csi/csi-release-tools/commit/adf00fe) Merge pull request #36 from msau42/full-clone
[f1697d2](https://github.com/kubernetes-csi/csi-release-tools/commit/f1697d2) Do full git clones in travis. Shallow clones are causing test-subtree errors when the depth is exactly 50.
[2c81919](https://github.com/kubernetes-csi/csi-release-tools/commit/2c81919) Merge pull request #34 from pohly/go-mod-tidy
[518d6af](https://github.com/kubernetes-csi/csi-release-tools/commit/518d6af) Merge pull request #35 from ddebroy/winbld2
[2d6b3ce](https://github.com/kubernetes-csi/csi-release-tools/commit/2d6b3ce) Build Windows only for amd64
[c1078a6](https://github.com/kubernetes-csi/csi-release-tools/commit/c1078a6) go-get-kubernetes.sh: automate Kubernetes dependency handling
[194289a](https://github.com/kubernetes-csi/csi-release-tools/commit/194289a) update Go mod support
[0affdf9](https://github.com/kubernetes-csi/csi-release-tools/commit/0affdf9) Merge pull request #33 from gnufied/enable-hostpath-expansion
[6208f6a](https://github.com/kubernetes-csi/csi-release-tools/commit/6208f6a) Enable hostpath expansion
[6ecaa76](https://github.com/kubernetes-csi/csi-release-tools/commit/6ecaa76) Merge pull request #30 from msau42/fix-windows
[ea2f1b5](https://github.com/kubernetes-csi/csi-release-tools/commit/ea2f1b5) build windows binaries with .exe suffix
[2d33550](https://github.com/kubernetes-csi/csi-release-tools/commit/2d33550) Merge pull request #29 from mucahitkurt/create-2-node-kind-cluster
[a8ea8bc](https://github.com/kubernetes-csi/csi-release-tools/commit/a8ea8bc) create 2-node kind cluster since topology support is added to hostpath driver
[df8530d](https://github.com/kubernetes-csi/csi-release-tools/commit/df8530d) Merge pull request #27 from pohly/dep-vendor-check
[35ceaed](https://github.com/kubernetes-csi/csi-release-tools/commit/35ceaed) prow.sh: install dep if needed
[f85ab5a](https://github.com/kubernetes-csi/csi-release-tools/commit/f85ab5a) Merge pull request #26 from ddebroy/windows1
[9fba09b](https://github.com/kubernetes-csi/csi-release-tools/commit/9fba09b) Add rule for building Windows binaries
[0400867](https://github.com/kubernetes-csi/csi-release-tools/commit/0400867) Merge pull request #25 from msau42/fix-master-jobs
[dc0a5d8](https://github.com/kubernetes-csi/csi-release-tools/commit/dc0a5d8) Update kind to v0.5.0
[aa85b82](https://github.com/kubernetes-csi/csi-release-tools/commit/aa85b82) Merge pull request #23 from msau42/fix-master-jobs
[f46191d](https://github.com/kubernetes-csi/csi-release-tools/commit/f46191d) Kubernetes master changed the way that releases are tagged, which needed changes to kind. There are 3 changes made to prow.sh:
[1cac3af](https://github.com/kubernetes-csi/csi-release-tools/commit/1cac3af) Merge pull request #22 from msau42/add-1.15-jobs
[0c0dc30](https://github.com/kubernetes-csi/csi-release-tools/commit/0c0dc30) prow.sh: tag master images with a large version number
[f4f73ce](https://github.com/kubernetes-csi/csi-release-tools/commit/f4f73ce) Merge pull request #21 from msau42/add-1.15-jobs
[4e31f07](https://github.com/kubernetes-csi/csi-release-tools/commit/4e31f07) Change default hostpath driver name to hostpath.csi.k8s.io
[4b6fa4a](https://github.com/kubernetes-csi/csi-release-tools/commit/4b6fa4a) Update hostpath version for sidecar testing to v1.2.0-rc2
[ecc7918](https://github.com/kubernetes-csi/csi-release-tools/commit/ecc7918) Update kind to v0.4.0. This requires overriding Kubernetes versions with specific patch versions that kind 0.4.0 supports. Also, feature gate setting is only supported on 1.15+ due to kind.sigs.k8s.io/v1alpha3 and kubeadm.k8s.io/v1beta2 dependencies.
[a6f21d4](https://github.com/kubernetes-csi/csi-release-tools/commit/a6f21d4) Add variables for 1.15
[db8abb6](https://github.com/kubernetes-csi/csi-release-tools/commit/db8abb6) Merge pull request #20 from pohly/test-driver-config
[b2f4e05](https://github.com/kubernetes-csi/csi-release-tools/commit/b2f4e05) prow.sh: flexible test driver config
[0399988](https://github.com/kubernetes-csi/csi-release-tools/commit/0399988) Merge pull request #19 from pohly/go-mod-vendor
[066143d](https://github.com/kubernetes-csi/csi-release-tools/commit/066143d) build.make: allow repos to use 'go mod' for vendoring
[0bee749](https://github.com/kubernetes-csi/csi-release-tools/commit/0bee749) Merge pull request #18 from pohly/go-version
[e157b6b](https://github.com/kubernetes-csi/csi-release-tools/commit/e157b6b) update to Go 1.12.4
[88dc9a4](https://github.com/kubernetes-csi/csi-release-tools/commit/88dc9a4) Merge pull request #17 from pohly/prow
[0fafc66](https://github.com/kubernetes-csi/csi-release-tools/commit/0fafc66) prow.sh: skip sanity testing if component doesn't support it
[bcac1c1](https://github.com/kubernetes-csi/csi-release-tools/commit/bcac1c1) Merge pull request #16 from pohly/prow
[0b10f6a](https://github.com/kubernetes-csi/csi-release-tools/commit/0b10f6a) prow.sh: update csi-driver-host-path
[0c2677e](https://github.com/kubernetes-csi/csi-release-tools/commit/0c2677e) Merge pull request #15 from pengzhisun/master
[ff9bce4](https://github.com/kubernetes-csi/csi-release-tools/commit/ff9bce4) Replace 'return' to 'exit' to fix shellcheck error
[c60f382](https://github.com/kubernetes-csi/csi-release-tools/commit/c60f382) Merge pull request #14 from pohly/prow
[7aaac22](https://github.com/kubernetes-csi/csi-release-tools/commit/7aaac22) prow.sh: remove AllAlpha=all, part II
[6617773](https://github.com/kubernetes-csi/csi-release-tools/commit/6617773) Merge pull request #13 from pohly/prow
[cda2fc5](https://github.com/kubernetes-csi/csi-release-tools/commit/cda2fc5) prow.sh: avoid AllAlpha=true
[546d550](https://github.com/kubernetes-csi/csi-release-tools/commit/546d550) prow.sh: debug failing KinD cluster creation
[9b0d9cd](https://github.com/kubernetes-csi/csi-release-tools/commit/9b0d9cd) build.make: skip shellcheck if Docker is not available
[aa45a1c](https://github.com/kubernetes-csi/csi-release-tools/commit/aa45a1c) prow.sh: more efficient execution of individual tests
[f3d1d2d](https://github.com/kubernetes-csi/csi-release-tools/commit/f3d1d2d) prow.sh: fix hostpath driver version check
[31dfaf3](https://github.com/kubernetes-csi/csi-release-tools/commit/31dfaf3) prow.sh: fix running of just "alpha" tests
[f501443](https://github.com/kubernetes-csi/csi-release-tools/commit/f501443) prow.sh: AllAlpha=true for unknown Kubernetes versions
[95ae9de](https://github.com/kubernetes-csi/csi-release-tools/commit/95ae9de) Merge pull request #9 from pohly/prow
[d87eccb](https://github.com/kubernetes-csi/csi-release-tools/commit/d87eccb) prow.sh: switch back to upstream csi-driver-host-path
[6602d38](https://github.com/kubernetes-csi/csi-release-tools/commit/6602d38) prow.sh: different E2E suite depending on Kubernetes version
[741319b](https://github.com/kubernetes-csi/csi-release-tools/commit/741319b) prow.sh: improve building Kubernetes from source
[29545bb](https://github.com/kubernetes-csi/csi-release-tools/commit/29545bb) prow.sh: take Go version from Kubernetes source
[429581c](https://github.com/kubernetes-csi/csi-release-tools/commit/429581c) prow.sh: pull Go version from travis.yml
[0a0fd49](https://github.com/kubernetes-csi/csi-release-tools/commit/0a0fd49) prow.sh: comment clarification
[2069a0a](https://github.com/kubernetes-csi/csi-release-tools/commit/2069a0a) Merge pull request #11 from pohly/verify-shellcheck
[55212ff](https://github.com/kubernetes-csi/csi-release-tools/commit/55212ff) initial Prow test job
[6c7ba1b](https://github.com/kubernetes-csi/csi-release-tools/commit/6c7ba1b) build.make: integrate shellcheck into "make test"
[b2d25d4](https://github.com/kubernetes-csi/csi-release-tools/commit/b2d25d4) verify-shellcheck.sh: make it usable in csi-release-tools
[3b6af7b](https://github.com/kubernetes-csi/csi-release-tools/commit/3b6af7b) Merge pull request #12 from pohly/local-e2e-suite
[104a1ac](https://github.com/kubernetes-csi/csi-release-tools/commit/104a1ac) build.make: avoid unit-testing E2E test suite
[34010e7](https://github.com/kubernetes-csi/csi-release-tools/commit/34010e7) Merge pull request #10 from pohly/vendor-check
[e6db50d](https://github.com/kubernetes-csi/csi-release-tools/commit/e6db50d) check vendor directory
[fb13c51](https://github.com/kubernetes-csi/csi-release-tools/commit/fb13c51) verify-shellcheck.sh: import from Kubernetes
[94fc1e3](https://github.com/kubernetes-csi/csi-release-tools/commit/94fc1e3) build.make: avoid unit-testing E2E test suite
[849db0a](https://github.com/kubernetes-csi/csi-release-tools/commit/849db0a) Merge pull request #8 from pohly/subtree-check-relax
[cc564f9](https://github.com/kubernetes-csi/csi-release-tools/commit/cc564f9) verify-subtree.sh: relax check and ignore old content
[33d58fd](https://github.com/kubernetes-csi/csi-release-tools/commit/33d58fd) Merge pull request #5 from pohly/test-enhancements
[be8a440](https://github.com/kubernetes-csi/csi-release-tools/commit/be8a440) Merge pull request #4 from pohly/canary-fix
[b0336b5](https://github.com/kubernetes-csi/csi-release-tools/commit/b0336b5) build.make: more readable "make test" output
[09436b9](https://github.com/kubernetes-csi/csi-release-tools/commit/09436b9) build.make: fix pushing of "canary" image from master branch
[147892c](https://github.com/kubernetes-csi/csi-release-tools/commit/147892c) build.make: support suppressing checks
[154e33d](https://github.com/kubernetes-csi/csi-release-tools/commit/154e33d) build.make: clarify usage of "make V=1"

git-subtree-dir: release-tools
git-subtree-split: 4aff857d88149e07951fcd1322f462f765401a86

```release-note
NONE
```