### PR TITLE
Prepare release v0.9.0

### DIFF
--- a/CHANGELOG/CHANGELOG-0.9.md
+++ b/CHANGELOG/CHANGELOG-0.9.md
@@ -1,0 +1,21 @@
+# Release notes for v0.9.0
+
+[Documentation](https://docs.k8s.io/docs/home)
+# Changelog since v0.8.1
+
+## Changes by Kind
+
+### Other (Cleanup or Flake)
+
+- Projects using csi-lib-utils should update to klog/v2 or must ensure that klog/v1 and klog/v2 are both configured as described in https://github.com/kubernetes/klog/blob/master/examples/coexist_klog_v1_and_v2/coexist_klog_v1_and_v2.go. ([#60](https://github.com/kubernetes-csi/csi-lib-utils/pull/60), [@pohly](https://github.com/pohly))
+
+## Dependencies
+
+### Added
+_Nothing has changed._
+
+### Changed
+_Nothing has changed._
+
+### Removed
+- k8s.io/klog: v1.0.0


### PR DESCRIPTION
Add changelog for a new release.

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
To get rid of `k8s.io/klog` v1 in all kubernetes-csi projects, we need to release csi-lib-utils that uses `k8s.io/klog/v2` and rebase is everywhere.

Downgrading ginkgo, gomega and groupcache is caused by #53 and looks OK to me.

**Which issue(s) this PR fixes**:
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

cc @msau42 @pohly 