### PR TITLE
connection.go: add V(5) to connecting message

### DIFF
--- a/connection/connection.go
+++ b/connection/connection.go
@@ -150,7 +150,7 @@ func connect(
 		return nil, errors.New("OnConnectionLoss callback only supported for unix:// addresses")
 	}
 
-	klog.Infof("Connecting to %s", address)
+	klog.V(5).Infof("Connecting to %s", address)
 
 	// Connect in background.
 	var conn *grpc.ClientConn


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Currently, the livenessprobe outputs this connection message for every check. This is a corollary to https://github.com/kubernetes-csi/livenessprobe/pull/88.

**Does this PR introduce a user-facing change?**:
```release-note
Default log level of connection message reduced to '4'.
```
