### PR TITLE
configurable timer for lease

### DIFF
--- a/leaderelection/leader_election.go
+++ b/leaderelection/leader_election.go
@@ -43,12 +43,45 @@ const (
 
 	DefaultHealthCheckTimeout = 20 * time.Second
 
+	nameLeaseDuration = "LEASEDURATION"
+	nameRenewDeadline = "RENEWDEADLINE"
+	nameRetryPeriod   = "RETRYPERIOD"
+	nameHealthCheckTimeout = "HEALTHCHECKTIMEOUT"
+
 	// HealthCheckerAddress is the address at which the leader election health
 	// checker reports status.
 	// The caller sidecar should document this address in appropriate flag
 	// descriptions.
 	HealthCheckerAddress = "/healthz/leader-election"
 )
+
+func getTimer(name string) time.Duration {
+
+    envDuration := os.Getenv(name)
+
+    if envDuration != "" {
+        i, err := time.ParseDuration(envDuration)
+        if err == nil {
+            return i
+        }
+    }
+
+    switch name {
+    case nameLeaseDuration:
+        return defaultLeaseDuration
+
+    case nameRenewDeadline:
+        return defaultRenewDeadline
+
+    case nameRetryPeriod:
+        return defaultRetryPeriod
+
+    case nameHealthCheckTimeout:
+        return DefaultHealthCheckTimeout
+    }
+
+    return 0
+}
 
 // leaderElection is a convenience wrapper around client-go's leader election library.
 type leaderElection struct {
@@ -88,9 +121,9 @@ func NewLeaderElectionWithLeases(clientset kubernetes.Interface, lockName string
 		runFunc:       runFunc,
 		lockName:      lockName,
 		resourceLock:  resourcelock.LeasesResourceLock,
-		leaseDuration: defaultLeaseDuration,
-		renewDeadline: defaultRenewDeadline,
-		retryPeriod:   defaultRetryPeriod,
+		leaseDuration: getTimer(nameLeaseDuration),
+		renewDeadline: getTimer(nameRenewDeadline),
+		retryPeriod:   getTimer(nameRetryPeriod),
 		clientset:     clientset,
 	}
 }
@@ -101,9 +134,9 @@ func NewLeaderElectionWithEndpoints(clientset kubernetes.Interface, lockName str
 		runFunc:       runFunc,
 		lockName:      lockName,
 		resourceLock:  resourcelock.EndpointsResourceLock,
-		leaseDuration: defaultLeaseDuration,
-		renewDeadline: defaultRenewDeadline,
-		retryPeriod:   defaultRetryPeriod,
+		leaseDuration: getTimer(nameLeaseDuration),
+		renewDeadline: getTimer(nameRenewDeadline),
+		retryPeriod:   getTimer(nameRetryPeriod),
 		clientset:     clientset,
 	}
 }
@@ -114,9 +147,9 @@ func NewLeaderElectionWithConfigMaps(clientset kubernetes.Interface, lockName st
 		runFunc:       runFunc,
 		lockName:      lockName,
 		resourceLock:  resourcelock.ConfigMapsResourceLock,
-		leaseDuration: defaultLeaseDuration,
-		renewDeadline: defaultRenewDeadline,
-		retryPeriod:   defaultRetryPeriod,
+		leaseDuration: getTimer(nameLeaseDuration),
+		renewDeadline: getTimer(nameRenewDeadline),
+		retryPeriod:   getTimer(nameRetryPeriod),
 		clientset:     clientset,
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
 /kind feature
> /kind flake

**What this PR does / why we need it**:
this PR is to make the lease related timer configurable from environment variable.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
below environment variables could be set: 
         LEASEDURATION:  default 15s
         RENEWDEADLINE: default 10s
         RETRYPERIOD: default 5s

```
