### PR TITLE
connection: exit with less output on connection loss

### DIFF
--- a/connection/connection.go
+++ b/connection/connection.go
@@ -84,7 +84,8 @@ func ExitOnConnectionLoss() func() bool {
 		if err := ioutil.WriteFile(terminationLogPath, []byte(terminationMsg), 0644); err != nil {
 			klog.Errorf("%s: %s", terminationLogPath, err)
 		}
-		klog.Fatalf(terminationMsg)
+		klog.Exit(terminationMsg)
+		// Not reached.
 		return false
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

klog.Fatal dumps information about all running goroutines when the
connection to the CSI driver is lost. Loosing the connection is normal
and depends on the order in which containers are shut down. If it
happens, then the reason is unlikely to be related to goroutines.

Therefore this extra output is not helpful or worse, fills up logfiles
when a sidecar has many goroutines, as in the external-provisioner
which runs 100 workers by default.

**Does this PR introduce a user-facing change?**:
```release-note
sidecars exit without output about goroutines when loosing the connection to the driver
```
