### PR TITLE
leader election: remove obsolete ConfigMapsResourceLock and EndpointsResourceLock

### DIFF
--- a/leaderelection/leader_election.go
+++ b/leaderelection/leader_election.go
@@ -61,8 +61,7 @@ type leaderElection struct {
 	// the namespace to store the lock resource
 	namespace string
 	// resourceLock defines the type of leaderelection that should be used
-	// valid options are resourcelock.LeasesResourceLock, resourcelock.EndpointsResourceLock,
-	// and resourcelock.ConfigMapsResourceLock
+	// Only resourcelock.LeasesResourceLock is valid at the moment.
 	resourceLock string
 	// healthCheck reports unhealthy if leader election fails to renew leadership
 	// within a timeout period.
@@ -88,32 +87,6 @@ func NewLeaderElectionWithLeases(clientset kubernetes.Interface, lockName string
 		runFunc:       runFunc,
 		lockName:      lockName,
 		resourceLock:  resourcelock.LeasesResourceLock,
-		leaseDuration: defaultLeaseDuration,
-		renewDeadline: defaultRenewDeadline,
-		retryPeriod:   defaultRetryPeriod,
-		clientset:     clientset,
-	}
-}
-
-// NewLeaderElectionWithEndpoints returns an implementation of leader election using Endpoints
-func NewLeaderElectionWithEndpoints(clientset kubernetes.Interface, lockName string, runFunc func(ctx context.Context)) *leaderElection {
-	return &leaderElection{
-		runFunc:       runFunc,
-		lockName:      lockName,
-		resourceLock:  resourcelock.EndpointsResourceLock,
-		leaseDuration: defaultLeaseDuration,
-		renewDeadline: defaultRenewDeadline,
-		retryPeriod:   defaultRetryPeriod,
-		clientset:     clientset,
-	}
-}
-
-// NewLeaderElectionWithConfigMaps returns an implementation of leader election using ConfigMaps
-func NewLeaderElectionWithConfigMaps(clientset kubernetes.Interface, lockName string, runFunc func(ctx context.Context)) *leaderElection {
-	return &leaderElection{
-		runFunc:       runFunc,
-		lockName:      lockName,
-		resourceLock:  resourcelock.ConfigMapsResourceLock,
 		leaseDuration: defaultLeaseDuration,
 		renewDeadline: defaultRenewDeadline,
 		retryPeriod:   defaultRetryPeriod,


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Kubernetes 1.24 won't support those anymore. To support building with a newer
client-go, csi-lib-utils must not reference the removed constants. This doesn't
affect the sidecars because those only use the default NewLeaderElection.

**Special notes for your reviewer**:

See https://github.com/kubernetes/kubernetes/commit/29d9683cd0fb3cc81810a8b39715e5eb4c68b00e

**Does this PR introduce a user-facing change?**:
```release-note
Leader election is only supported for leases via NewLeaderElection.
```
