### PR TITLE
release v0.11.0

### DIFF
--- a/CHANGELOG/CHANGELOG-0.11.md
+++ b/CHANGELOG/CHANGELOG-0.11.md
@@ -1,0 +1,19 @@
+# Release notes for v0.11.0
+
+# Changelog since v0.10.0
+
+## Changes by Kind
+
+### Other (Cleanup or Flake)
+ - Leader election is only supported for leases via NewLeaderElection. ([#109](https://github.com/kubernetes-csi/csi-lib-utils/pull/109), [@pohly](https://github.com/pohly))
+
+## Dependencies
+
+### Added
+_Nothing has changed._
+
+### Changed
+_Nothing has changed._
+
+### Removed
+_Nothing has changed._


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:

We need a formal release that is compatible with Kubernetes 1.24.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
