### PR TITLE
Automated cherry pick of #81: connection: exit with less output on connection loss

### DIFF
--- a/connection/connection.go
+++ b/connection/connection.go
@@ -84,7 +84,8 @@ func ExitOnConnectionLoss() func() bool {
 		if err := ioutil.WriteFile(terminationLogPath, []byte(terminationMsg), 0644); err != nil {
 			klog.Errorf("%s: %s", terminationLogPath, err)
 		}
-		klog.Fatalf(terminationMsg)
+		klog.Exit(terminationMsg)
+		// Not reached.
 		return false
 	}
 }


### PR DESCRIPTION
/sig storage
/kind bug

Cherry pick of #81 on release-0.9.

#81: connection: exit with less output on connection loss

Part of https://github.com/kubernetes-csi/external-provisioner/issues/732

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
sidecars exit without output about goroutines when losing the connection to the driver
```


For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.