### PR TITLE
add WithCustomRegistry for metrics

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -179,6 +179,13 @@ func WithProcessStartTime(registerProcessStartTime bool) MetricsManagerOption {
 	}
 }
 
+// WithCustomRegistry allow user to use custom pre-created registry instead of a new created one.
+func WithCustomRegistry(registry metrics.KubeRegistry) MetricsManagerOption {
+	return func(cmm *csiMetricsManager) {
+		cmm.registry = registry
+	}
+}
+
 // NewCSIMetricsManagerForSidecar creates and registers metrics for CSI Sidecars and
 // returns an object that can be used to trigger the metrics. It uses "csi_sidecar"
 // as subsystem.


### PR DESCRIPTION
**What type of PR is this?**

> /kind feature

**What this PR does / why we need it**:
If users want to monitor workqueue metrics, they usually import `k8s.io/component-base/metrics/prometheus/workqueue`, which registers to `k8s.io/component-base/metrics/legacyregistry`, however, `csiMetricsManager` is using its own newly-created registry.

**Which issue(s) this PR fixes**:
Make a new method `WithCustomRegistry` to let users pass in an exist registry.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
Adds WithCustomRegistry method to the metrics pkg to allow reuse of an existing registry.
```
