### PR TITLE
Add release-note/changelog for v0.12.0

### DIFF
--- a/CHANGELOG/CHANGELOG-0.12.md
+++ b/CHANGELOG/CHANGELOG-0.12.md
@@ -1,0 +1,204 @@
+# Release notes for v0.12.0
+
+# Changelog since v0.11.0
+
+## Changes by Kind
+
+### Other (Cleanup or Flake)
+
+### Uncategorized
+
+- Adds WithCustomRegistry method to the metrics pkg to allow reuse of an existing registry. ([#118](https://github.com/kubernetes-csi/csi-lib-utils/pull/118), [@ayanamist](https://github.com/ayanamist))
+
+## Dependencies
+
+### Added
+- github.com/armon/go-socks5: [e753329](https://github.com/armon/go-socks5/tree/e753329)
+- github.com/blang/semver/v4: [v4.0.0](https://github.com/blang/semver/v4/tree/v4.0.0)
+- github.com/cenkalti/backoff/v4: [v4.1.3](https://github.com/cenkalti/backoff/v4/tree/v4.1.3)
+- github.com/cncf/xds/go: [cb28da3](https://github.com/cncf/xds/go/tree/cb28da3)
+- github.com/emicklei/go-restful/v3: [v3.9.0](https://github.com/emicklei/go-restful/v3/tree/v3.9.0)
+- github.com/go-logr/stdr: [v1.2.2](https://github.com/go-logr/stdr/tree/v1.2.2)
+- github.com/go-logr/zapr: [v1.2.3](https://github.com/go-logr/zapr/tree/v1.2.3)
+- github.com/google/gnostic: [v0.5.7-v3refs](https://github.com/google/gnostic/tree/v0.5.7-v3refs)
+- github.com/google/martian/v3: [v3.0.0](https://github.com/google/martian/v3/tree/v3.0.0)
+- github.com/grpc-ecosystem/grpc-gateway/v2: [v2.7.0](https://github.com/grpc-ecosystem/grpc-gateway/v2/tree/v2.7.0)
+- github.com/josharian/intern: [v1.0.0](https://github.com/josharian/intern/tree/v1.0.0)
+- github.com/onsi/ginkgo/v2: [v2.4.0](https://github.com/onsi/ginkgo/v2/tree/v2.4.0)
+- go.opentelemetry.io/otel/exporters/otlp/internal/retry: v1.10.0
+- go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc: v1.10.0
+- go.opentelemetry.io/otel/exporters/otlp/otlptrace: v1.10.0
+- go.uber.org/goleak: v1.2.0
+- sigs.k8s.io/json: f223a00
+
+### Changed
+- cloud.google.com/go/bigquery: v1.4.0 → v1.8.0
+- cloud.google.com/go/pubsub: v1.2.0 → v1.3.1
+- cloud.google.com/go/storage: v1.6.0 → v1.10.0
+- cloud.google.com/go: v0.54.0 → v0.65.0
+- github.com/cespare/xxhash/v2: [v2.1.1 → v2.1.2](https://github.com/cespare/xxhash/v2/compare/v2.1.1...v2.1.2)
+- github.com/cncf/udpa/go: [5459f2c → 04548b0](https://github.com/cncf/udpa/go/compare/5459f2c...04548b0)
+- github.com/container-storage-interface/spec: [v1.5.0 → v1.7.0](https://github.com/container-storage-interface/spec/compare/v1.5.0...v1.7.0)
+- github.com/creack/pty: [v1.1.11 → v1.1.9](https://github.com/creack/pty/compare/v1.1.11...v1.1.9)
+- github.com/envoyproxy/go-control-plane: [668b12f → 49ff273](https://github.com/envoyproxy/go-control-plane/compare/668b12f...49ff273)
+- github.com/evanphx/json-patch: [v4.11.0+incompatible → v4.12.0+incompatible](https://github.com/evanphx/json-patch/compare/v4.11.0...v4.12.0)
+- github.com/felixge/httpsnoop: [v1.0.1 → v1.0.3](https://github.com/felixge/httpsnoop/compare/v1.0.1...v1.0.3)
+- github.com/go-kit/log: [v0.1.0 → v0.2.0](https://github.com/go-kit/log/compare/v0.1.0...v0.2.0)
+- github.com/go-logfmt/logfmt: [v0.5.0 → v0.5.1](https://github.com/go-logfmt/logfmt/compare/v0.5.0...v0.5.1)
+- github.com/go-logr/logr: [v0.4.0 → v1.2.3](https://github.com/go-logr/logr/compare/v0.4.0...v1.2.3)
+- github.com/go-openapi/jsonpointer: [v0.19.3 → v0.19.5](https://github.com/go-openapi/jsonpointer/compare/v0.19.3...v0.19.5)
+- github.com/go-openapi/jsonreference: [v0.19.3 → v0.20.0](https://github.com/go-openapi/jsonreference/compare/v0.19.3...v0.20.0)
+- github.com/go-openapi/swag: [v0.19.5 → v0.19.14](https://github.com/go-openapi/swag/compare/v0.19.5...v0.19.14)
+- github.com/golang/mock: [v1.4.1 → v1.4.4](https://github.com/golang/mock/compare/v1.4.1...v1.4.4)
+- github.com/google/go-cmp: [v0.5.5 → v0.5.9](https://github.com/google/go-cmp/compare/v0.5.5...v0.5.9)
+- github.com/google/pprof: [1ebb73c → 1a94d86](https://github.com/google/pprof/compare/1ebb73c...1a94d86)
+- github.com/imdario/mergo: [v0.3.5 → v0.3.6](https://github.com/imdario/mergo/compare/v0.3.5...v0.3.6)
+- github.com/inconshreveable/mousetrap: [v1.0.0 → v1.0.1](https://github.com/inconshreveable/mousetrap/compare/v1.0.0...v1.0.1)
+- github.com/json-iterator/go: [v1.1.11 → v1.1.12](https://github.com/json-iterator/go/compare/v1.1.11...v1.1.12)
+- github.com/mailru/easyjson: [b2ccc51 → v0.7.6](https://github.com/mailru/easyjson/compare/b2ccc51...v0.7.6)
+- github.com/matttproud/golang_protobuf_extensions: [c182aff → v1.0.2](https://github.com/matttproud/golang_protobuf_extensions/compare/c182aff...v1.0.2)
+- github.com/moby/term: [9d4ed18 → 39b0c02](https://github.com/moby/term/compare/9d4ed18...39b0c02)
+- github.com/modern-go/reflect2: [v1.0.1 → v1.0.2](https://github.com/modern-go/reflect2/compare/v1.0.1...v1.0.2)
+- github.com/munnerz/goautoneg: [a547fc6 → a7dc8b6](https://github.com/munnerz/goautoneg/compare/a547fc6...a7dc8b6)
+- github.com/onsi/gomega: [v1.10.1 → v1.23.0](https://github.com/onsi/gomega/compare/v1.10.1...v1.23.0)
+- github.com/prometheus/client_golang: [v1.11.0 → v1.14.0](https://github.com/prometheus/client_golang/compare/v1.11.0...v1.14.0)
+- github.com/prometheus/client_model: [v0.2.0 → v0.3.0](https://github.com/prometheus/client_model/compare/v0.2.0...v0.3.0)
+- github.com/prometheus/common: [v0.26.0 → v0.37.0](https://github.com/prometheus/common/compare/v0.26.0...v0.37.0)
+- github.com/prometheus/procfs: [v0.6.0 → v0.8.0](https://github.com/prometheus/procfs/compare/v0.6.0...v0.8.0)
+- github.com/spf13/cobra: [v1.1.3 → v1.6.0](https://github.com/spf13/cobra/compare/v1.1.3...v1.6.0)
+- github.com/stretchr/objx: [v0.1.1 → v0.4.0](https://github.com/stretchr/objx/compare/v0.1.1...v0.4.0)
+- github.com/stretchr/testify: [v1.7.0 → v1.8.0](https://github.com/stretchr/testify/compare/v1.7.0...v1.8.0)
+- github.com/yuin/goldmark: [v1.3.5 → v1.2.1](https://github.com/yuin/goldmark/compare/v1.3.5...v1.2.1)
+- go.opencensus.io: v0.22.3 → v0.22.4
+- go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp: v0.20.0 → v0.35.0
+- go.opentelemetry.io/otel/metric: v0.20.0 → v0.31.0
+- go.opentelemetry.io/otel/sdk: v0.20.0 → v1.10.0
+- go.opentelemetry.io/otel/trace: v0.20.0 → v1.10.0
+- go.opentelemetry.io/otel: v0.20.0 → v1.10.0
+- go.opentelemetry.io/proto/otlp: v0.7.0 → v0.19.0
+- go.uber.org/zap: v1.17.0 → v1.19.0
+- golang.org/x/crypto: 5ea612d → 75b2880
+- golang.org/x/lint: 6edffad → 738671d
+- golang.org/x/mod: v0.4.2 → 86c51ed
+- golang.org/x/net: 37e1c6a → v0.4.0
+- golang.org/x/oauth2: bf48bf1 → ee48083
+- golang.org/x/sync: 036812b → 0de741c
+- golang.org/x/sys: 59db8d7 → v0.3.0
+- golang.org/x/term: 6a3ed07 → v0.3.0
+- golang.org/x/text: v0.3.6 → v0.5.0
+- golang.org/x/time: 1f47c86 → 90d013b
+- golang.org/x/tools: v0.1.2 → v0.1.12
+- google.golang.org/api: v0.20.0 → v0.30.0
+- google.golang.org/appengine: v1.6.5 → v1.6.7
+- google.golang.org/genproto: f16073e → c8bf987
+- google.golang.org/grpc: v1.38.0 → v1.49.0
+- google.golang.org/protobuf: v1.26.0 → v1.28.1
+- gopkg.in/yaml.v3: 496545a → v3.0.1
+- honnef.co/go/tools: v0.0.1-2020.1.3 → v0.0.1-2020.1.4
+- k8s.io/api: v0.22.0 → v0.26.0
+- k8s.io/apimachinery: v0.22.0 → v0.26.0
+- k8s.io/client-go: v0.22.0 → v0.26.0
+- k8s.io/component-base: v0.22.0 → v0.26.0
+- k8s.io/gengo: 3a45101 → 485abfe
+- k8s.io/klog/v2: v2.9.0 → v2.80.1
+- k8s.io/kube-openapi: 9528897 → 172d655
+- k8s.io/utils: 4b05e18 → 1a15be2
+- sigs.k8s.io/structured-merge-diff/v4: v4.1.2 → v4.2.3
+- sigs.k8s.io/yaml: v1.2.0 → v1.3.0
+
+### Removed
+- cloud.google.com/go/firestore: v1.1.0
+- github.com/Azure/go-autorest/autorest/adal: [v0.9.13](https://github.com/Azure/go-autorest/autorest/adal/tree/v0.9.13)
+- github.com/Azure/go-autorest/autorest/date: [v0.3.0](https://github.com/Azure/go-autorest/autorest/date/tree/v0.3.0)
+- github.com/Azure/go-autorest/autorest/mocks: [v0.4.1](https://github.com/Azure/go-autorest/autorest/mocks/tree/v0.4.1)
+- github.com/Azure/go-autorest/autorest: [v0.11.18](https://github.com/Azure/go-autorest/autorest/tree/v0.11.18)
+- github.com/Azure/go-autorest/logger: [v0.2.1](https://github.com/Azure/go-autorest/logger/tree/v0.2.1)
+- github.com/Azure/go-autorest/tracing: [v0.6.0](https://github.com/Azure/go-autorest/tracing/tree/v0.6.0)
+- github.com/Azure/go-autorest: [v14.2.0+incompatible](https://github.com/Azure/go-autorest/tree/v14.2.0)
+- github.com/OneOfOne/xxhash: [v1.2.2](https://github.com/OneOfOne/xxhash/tree/v1.2.2)
+- github.com/armon/circbuf: [bbbad09](https://github.com/armon/circbuf/tree/bbbad09)
+- github.com/armon/go-metrics: [f0300d1](https://github.com/armon/go-metrics/tree/f0300d1)
+- github.com/armon/go-radix: [7fddfc3](https://github.com/armon/go-radix/tree/7fddfc3)
+- github.com/benbjohnson/clock: [v1.0.3](https://github.com/benbjohnson/clock/tree/v1.0.3)
+- github.com/bgentry/speakeasy: [v0.1.0](https://github.com/bgentry/speakeasy/tree/v0.1.0)
+- github.com/bketelsen/crypt: [5cbc8cc](https://github.com/bketelsen/crypt/tree/5cbc8cc)
+- github.com/blang/semver: [v3.5.1+incompatible](https://github.com/blang/semver/tree/v3.5.1)
+- github.com/cespare/xxhash: [v1.1.0](https://github.com/cespare/xxhash/tree/v1.1.0)
+- github.com/coreos/bbolt: [v1.3.2](https://github.com/coreos/bbolt/tree/v1.3.2)
+- github.com/coreos/etcd: [v3.3.13+incompatible](https://github.com/coreos/etcd/tree/v3.3.13)
+- github.com/coreos/go-semver: [v0.3.0](https://github.com/coreos/go-semver/tree/v0.3.0)
+- github.com/coreos/go-systemd: [95778df](https://github.com/coreos/go-systemd/tree/95778df)
+- github.com/coreos/pkg: [399ea9e](https://github.com/coreos/pkg/tree/399ea9e)
+- github.com/cpuguy83/go-md2man/v2: [v2.0.0](https://github.com/cpuguy83/go-md2man/v2/tree/v2.0.0)
+- github.com/dgrijalva/jwt-go: [v3.2.0+incompatible](https://github.com/dgrijalva/jwt-go/tree/v3.2.0)
+- github.com/dgryski/go-sip13: [e10d5fe](https://github.com/dgryski/go-sip13/tree/e10d5fe)
+- github.com/emicklei/go-restful: [ff4f55a](https://github.com/emicklei/go-restful/tree/ff4f55a)
+- github.com/fatih/color: [v1.7.0](https://github.com/fatih/color/tree/v1.7.0)
+- github.com/form3tech-oss/jwt-go: [v3.2.3+incompatible](https://github.com/form3tech-oss/jwt-go/tree/v3.2.3)
+- github.com/fsnotify/fsnotify: [v1.4.9](https://github.com/fsnotify/fsnotify/tree/v1.4.9)
+- github.com/googleapis/gnostic: [v0.5.5](https://github.com/googleapis/gnostic/tree/v0.5.5)
+- github.com/gopherjs/gopherjs: [0766667](https://github.com/gopherjs/gopherjs/tree/0766667)
+- github.com/gorilla/websocket: [v1.4.2](https://github.com/gorilla/websocket/tree/v1.4.2)
+- github.com/grpc-ecosystem/go-grpc-middleware: [v1.0.0](https://github.com/grpc-ecosystem/go-grpc-middleware/tree/v1.0.0)
+- github.com/grpc-ecosystem/go-grpc-prometheus: [v1.2.0](https://github.com/grpc-ecosystem/go-grpc-prometheus/tree/v1.2.0)
+- github.com/hashicorp/consul/api: [v1.1.0](https://github.com/hashicorp/consul/api/tree/v1.1.0)
+- github.com/hashicorp/consul/sdk: [v0.1.1](https://github.com/hashicorp/consul/sdk/tree/v0.1.1)
+- github.com/hashicorp/errwrap: [v1.0.0](https://github.com/hashicorp/errwrap/tree/v1.0.0)
+- github.com/hashicorp/go-cleanhttp: [v0.5.1](https://github.com/hashicorp/go-cleanhttp/tree/v0.5.1)
+- github.com/hashicorp/go-immutable-radix: [v1.0.0](https://github.com/hashicorp/go-immutable-radix/tree/v1.0.0)
+- github.com/hashicorp/go-msgpack: [v0.5.3](https://github.com/hashicorp/go-msgpack/tree/v0.5.3)
+- github.com/hashicorp/go-multierror: [v1.0.0](https://github.com/hashicorp/go-multierror/tree/v1.0.0)
+- github.com/hashicorp/go-rootcerts: [v1.0.0](https://github.com/hashicorp/go-rootcerts/tree/v1.0.0)
+- github.com/hashicorp/go-sockaddr: [v1.0.0](https://github.com/hashicorp/go-sockaddr/tree/v1.0.0)
+- github.com/hashicorp/go-syslog: [v1.0.0](https://github.com/hashicorp/go-syslog/tree/v1.0.0)
+- github.com/hashicorp/go-uuid: [v1.0.1](https://github.com/hashicorp/go-uuid/tree/v1.0.1)
+- github.com/hashicorp/go.net: [v0.0.1](https://github.com/hashicorp/go.net/tree/v0.0.1)
+- github.com/hashicorp/hcl: [v1.0.0](https://github.com/hashicorp/hcl/tree/v1.0.0)
+- github.com/hashicorp/logutils: [v1.0.0](https://github.com/hashicorp/logutils/tree/v1.0.0)
+- github.com/hashicorp/mdns: [v1.0.0](https://github.com/hashicorp/mdns/tree/v1.0.0)
+- github.com/hashicorp/memberlist: [v0.1.3](https://github.com/hashicorp/memberlist/tree/v0.1.3)
+- github.com/hashicorp/serf: [v0.8.2](https://github.com/hashicorp/serf/tree/v0.8.2)
+- github.com/hpcloud/tail: [v1.0.0](https://github.com/hpcloud/tail/tree/v1.0.0)
+- github.com/jonboulle/clockwork: [v0.1.0](https://github.com/jonboulle/clockwork/tree/v0.1.0)
+- github.com/jtolds/gls: [v4.20.0+incompatible](https://github.com/jtolds/gls/tree/v4.20.0)
+- github.com/magiconair/properties: [v1.8.1](https://github.com/magiconair/properties/tree/v1.8.1)
+- github.com/mattn/go-colorable: [v0.0.9](https://github.com/mattn/go-colorable/tree/v0.0.9)
+- github.com/mattn/go-isatty: [v0.0.3](https://github.com/mattn/go-isatty/tree/v0.0.3)
+- github.com/miekg/dns: [v1.0.14](https://github.com/miekg/dns/tree/v1.0.14)
+- github.com/mitchellh/cli: [v1.0.0](https://github.com/mitchellh/cli/tree/v1.0.0)
+- github.com/mitchellh/go-homedir: [v1.1.0](https://github.com/mitchellh/go-homedir/tree/v1.1.0)
+- github.com/mitchellh/go-testing-interface: [v1.0.0](https://github.com/mitchellh/go-testing-interface/tree/v1.0.0)
+- github.com/mitchellh/gox: [v0.4.0](https://github.com/mitchellh/gox/tree/v0.4.0)
+- github.com/mitchellh/iochan: [v1.0.0](https://github.com/mitchellh/iochan/tree/v1.0.0)
+- github.com/nxadm/tail: [v1.4.4](https://github.com/nxadm/tail/tree/v1.4.4)
+- github.com/oklog/ulid: [v1.3.1](https://github.com/oklog/ulid/tree/v1.3.1)
+- github.com/onsi/ginkgo: [v1.14.0](https://github.com/onsi/ginkgo/tree/v1.14.0)
+- github.com/pascaldekloe/goe: [57f6aae](https://github.com/pascaldekloe/goe/tree/57f6aae)
+- github.com/pelletier/go-toml: [v1.2.0](https://github.com/pelletier/go-toml/tree/v1.2.0)
+- github.com/posener/complete: [v1.1.1](https://github.com/posener/complete/tree/v1.1.1)
+- github.com/prometheus/tsdb: [v0.7.1](https://github.com/prometheus/tsdb/tree/v0.7.1)
+- github.com/russross/blackfriday/v2: [v2.0.1](https://github.com/russross/blackfriday/v2/tree/v2.0.1)
+- github.com/ryanuber/columnize: [9b3edd6](https://github.com/ryanuber/columnize/tree/9b3edd6)
+- github.com/sean-/seed: [e2103e2](https://github.com/sean-/seed/tree/e2103e2)
+- github.com/shurcooL/sanitized_anchor_name: [v1.0.0](https://github.com/shurcooL/sanitized_anchor_name/tree/v1.0.0)
+- github.com/smartystreets/assertions: [b2de0cb](https://github.com/smartystreets/assertions/tree/b2de0cb)
+- github.com/smartystreets/goconvey: [v1.6.4](https://github.com/smartystreets/goconvey/tree/v1.6.4)
+- github.com/soheilhy/cmux: [v0.1.4](https://github.com/soheilhy/cmux/tree/v0.1.4)
+- github.com/spaolacci/murmur3: [f09979e](https://github.com/spaolacci/murmur3/tree/f09979e)
+- github.com/spf13/afero: [v1.2.2](https://github.com/spf13/afero/tree/v1.2.2)
+- github.com/spf13/cast: [v1.3.0](https://github.com/spf13/cast/tree/v1.3.0)
+- github.com/spf13/jwalterweatherman: [v1.0.0](https://github.com/spf13/jwalterweatherman/tree/v1.0.0)
+- github.com/spf13/viper: [v1.7.0](https://github.com/spf13/viper/tree/v1.7.0)
+- github.com/subosito/gotenv: [v1.2.0](https://github.com/subosito/gotenv/tree/v1.2.0)
+- github.com/tmc/grpc-websocket-proxy: [0ad062e](https://github.com/tmc/grpc-websocket-proxy/tree/0ad062e)
+- github.com/xiang90/probing: [43a291a](https://github.com/xiang90/probing/tree/43a291a)
+- go.etcd.io/bbolt: v1.3.2
+- go.opentelemetry.io/contrib: v0.20.0
+- go.opentelemetry.io/otel/exporters/otlp: v0.20.0
+- go.opentelemetry.io/otel/oteltest: v0.20.0
+- go.opentelemetry.io/otel/sdk/export/metric: v0.20.0
+- go.opentelemetry.io/otel/sdk/metric: v0.20.0
+- gopkg.in/fsnotify.v1: v1.4.7
+- gopkg.in/ini.v1: v1.51.0
+- gopkg.in/resty.v1: v1.12.0
+- gopkg.in/tomb.v1: dd63297


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design

/kind documentation

> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

I ran release note sha diff of:
```
release-notes \
  --org=kubernetes-csi \
  --repo=csi-lib-utils \
  --start-rev=release-0.11 \
  --discover=mergebase-to-latest \
  --required-author="" \
  --markdown-links \
  --output out.md
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
