### PR TITLE
Update dependency go modules for k8s v1.28.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -61,3 +61,11 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+replace k8s.io/api => k8s.io/api v0.28.0
+
+replace k8s.io/apimachinery => k8s.io/apimachinery v0.28.0
+
+replace k8s.io/client-go => k8s.io/client-go v0.28.0
+
+replace k8s.io/component-base => k8s.io/component-base v0.28.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -260,7 +260,7 @@ gopkg.in/yaml.v2
 # gopkg.in/yaml.v3 v3.0.1
 ## explicit
 gopkg.in/yaml.v3
-# k8s.io/api v0.28.0
+# k8s.io/api v0.28.0 => k8s.io/api v0.28.0
 ## explicit; go 1.20
 k8s.io/api/admissionregistration/v1
 k8s.io/api/admissionregistration/v1alpha1
@@ -314,7 +314,7 @@ k8s.io/api/scheduling/v1beta1
 k8s.io/api/storage/v1
 k8s.io/api/storage/v1alpha1
 k8s.io/api/storage/v1beta1
-# k8s.io/apimachinery v0.28.0
+# k8s.io/apimachinery v0.28.0 => k8s.io/apimachinery v0.28.0
 ## explicit; go 1.20
 k8s.io/apimachinery/pkg/api/equality
 k8s.io/apimachinery/pkg/api/errors
@@ -360,7 +360,7 @@ k8s.io/apimachinery/pkg/version
 k8s.io/apimachinery/pkg/watch
 k8s.io/apimachinery/third_party/forked/golang/json
 k8s.io/apimachinery/third_party/forked/golang/reflect
-# k8s.io/client-go v0.28.0
+# k8s.io/client-go v0.28.0 => k8s.io/client-go v0.28.0
 ## explicit; go 1.20
 k8s.io/client-go/applyconfigurations/admissionregistration/v1
 k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1
@@ -486,7 +486,7 @@ k8s.io/client-go/util/connrotation
 k8s.io/client-go/util/flowcontrol
 k8s.io/client-go/util/keyutil
 k8s.io/client-go/util/workqueue
-# k8s.io/component-base v0.28.0
+# k8s.io/component-base v0.28.0 => k8s.io/component-base v0.28.0
 ## explicit; go 1.20
 k8s.io/component-base/metrics
 k8s.io/component-base/metrics/legacyregistry
@@ -537,3 +537,7 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
+# k8s.io/api => k8s.io/api v0.28.0
+# k8s.io/apimachinery => k8s.io/apimachinery v0.28.0
+# k8s.io/client-go => k8s.io/client-go v0.28.0
+# k8s.io/component-base => k8s.io/component-base v0.28.0


### PR DESCRIPTION
Ran kubernetes-csi/csi-release-tools go-get-kubernetes.sh -p 1.28.0 
            