### PR TITLE
Migrate from io/ioutil package to io and os packages

### DIFF
--- a/connection/connection.go
+++ b/connection/connection.go
@@ -20,8 +20,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 	"strings"
 	"time"
 
@@ -107,7 +107,7 @@ func OnConnectionLoss(reconnect func() bool) Option {
 func ExitOnConnectionLoss() func() bool {
 	return func() bool {
 		terminationMsg := "Lost connection to CSI driver, exiting"
-		if err := ioutil.WriteFile(terminationLogPath, []byte(terminationMsg), 0644); err != nil {
+		if err := os.WriteFile(terminationLogPath, []byte(terminationMsg), 0644); err != nil {
 			klog.Errorf("%s: %s", terminationLogPath, err)
 		}
 		klog.Exit(terminationMsg)

--- a/connection/connection_test.go
+++ b/connection/connection_test.go
@@ -18,7 +18,6 @@ package connection
 
 import (
 	"context"
-	"io/ioutil"
 	"net"
 	"os"
 	"path"
@@ -43,7 +42,7 @@ import (
 )
 
 func tmpDir(t *testing.T) string {
-	dir, err := ioutil.TempDir("", "connect")
+	dir, err := os.MkdirTemp("", "connect")
 	require.NoError(t, err, "creating temp directory")
 	return dir
 }

--- a/leaderelection/leader_election.go
+++ b/leaderelection/leader_election.go
@@ -19,7 +19,6 @@ package leaderelection
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"regexp"
@@ -219,7 +218,7 @@ func inClusterNamespace() string {
 		return ns
 	}
 
-	if data, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
+	if data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
 		if ns := strings.TrimSpace(string(data)); len(ns) > 0 {
 			return ns
 		}

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package metrics
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -506,7 +506,7 @@ func TestRegisterToServer_Noop(t *testing.T) {
 		t.Fatalf("/metrics response status not 200. Response was: %+v", resp)
 	}
 
-	contentBytes, err := ioutil.ReadAll(resp.Body)
+	contentBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("Failed to parse metrics response.  Response was: %+v Error: %v", resp, err)
 	}
@@ -572,7 +572,7 @@ func testRegisterPprofToServer_AllEndpointsAvailable(t *testing.T, endpoint stri
 		t.Fatalf("%s response status not 200. Response was: %+v", endpoint, resp)
 	}
 
-	contentBytes, err := ioutil.ReadAll(resp.Body)
+	contentBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("Failed to parse pprof index response.  Response was: %+v Error: %v", resp, err)
 	}

--- a/rpc/common_test.go
+++ b/rpc/common_test.go
@@ -19,7 +19,6 @@ package rpc
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path"
@@ -40,7 +39,7 @@ import (
 )
 
 func tmpDir(t *testing.T) string {
-	dir, err := ioutil.TempDir("", "connect")
+	dir, err := os.MkdirTemp("", "connect")
 	require.NoError(t, err, "creating temp directory")
 	return dir
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake
-->

/kind cleanup

**What this PR does / why we need it**:

As mentioned in the article below, the io/ioutil package has been deprecated. Therefore, I've migrated to the functions added to the io and os packages.
https://tip.golang.org/doc/go1.16#ioutil


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Fixes #
-->


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
