### PR TITLE
Bump logcheck to 0.8.2

### DIFF
--- a/hack/verify-logcheck.sh
+++ b/hack/verify-logcheck.sh
@@ -21,7 +21,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-LOGCHECK_VERSION=${1:-0.8.1}
+LOGCHECK_VERSION=${1:-0.8.2}
 
 # This will canonicalize the path
 CSI_LIB_UTIL_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd -P)


### PR DESCRIPTION
A panic with go 1.22 should be fixed there: https://github.com/kubernetes-sigs/logtools/issues/28

/kind bug

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
