### PR TITLE
Makefile: include header for logcheck test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,4 +23,5 @@ include release-tools/build.make
 .PHONY: logcheck
 test: logcheck
 logcheck:
+	@ echo; echo "### $@:"
 	hack/verify-logcheck.sh


### PR DESCRIPTION

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This is needed to ensure proper separation of different tests.

**Special notes for your reviewer**:

For example, here a logcheck failure was reported as shellcheck failure:

https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-csi_csi-lib-utils/165/pull-kubernetes-csi-csi-lib-utils/1787827549770878976


**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
