### PR TITLE
Restore ProbeForever behavior of probing first before sleeping

### DIFF
--- a/rpc/common.go
+++ b/rpc/common.go
@@ -136,6 +136,7 @@ func GetGroupControllerCapabilities(ctx context.Context, conn *grpc.ClientConn) 
 func ProbeForever(ctx context.Context, conn *grpc.ClientConn, singleProbeTimeout time.Duration) error {
 	logger := klog.FromContext(ctx)
 	ticker := time.NewTicker(probeInterval)
+	defer ticker.Stop()
 
 	for {
 		select {

--- a/rpc/common.go
+++ b/rpc/common.go
@@ -139,30 +139,32 @@ func ProbeForever(ctx context.Context, conn *grpc.ClientConn, singleProbeTimeout
 	defer ticker.Stop()
 
 	for {
+		// Run the probe once before waiting for the ticker
+		logger.Info("Probing CSI driver for readiness")
+		ready, err := probeOnce(ctx, conn, singleProbeTimeout)
+		if err != nil {
+			st, ok := status.FromError(err)
+			if !ok {
+				// This is not gRPC error. The probe must have failed before gRPC
+				// method was called, otherwise we would get gRPC error.
+				return fmt.Errorf("CSI driver probe failed: %s", err)
+			}
+			if st.Code() != codes.DeadlineExceeded {
+				return fmt.Errorf("CSI driver probe failed: %s", err)
+			}
+			// Timeout -> driver is not ready. Fall through to sleep() below.
+			logger.Info("CSI driver probe timed out")
+		} else {
+			if ready {
+				return nil
+			}
+			logger.Info("CSI driver is not ready")
+		}
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-ticker.C:
-			logger.Info("Probing CSI driver for readiness")
-			ready, err := probeOnce(ctx, conn, singleProbeTimeout)
-			if err != nil {
-				st, ok := status.FromError(err)
-				if !ok {
-					// This is not gRPC error. The probe must have failed before gRPC
-					// method was called, otherwise we would get gRPC error.
-					return fmt.Errorf("CSI driver probe failed: %s", err)
-				}
-				if st.Code() != codes.DeadlineExceeded {
-					return fmt.Errorf("CSI driver probe failed: %s", err)
-				}
-				// Timeout -> driver is not ready. Fall through to sleep() below.
-				logger.Info("CSI driver probe timed out")
-			} else {
-				if ready {
-					return nil
-				}
-				logger.Info("CSI driver is not ready")
-			}
+			continue
 		}
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The previous beheavior of ProbeForever was to try a probe and then sleep for the `probeInterval` duration. When it was modified to use a `time.Ticker` instead of a sleep in https://github.com/kubernetes-csi/csi-lib-utils/pull/149, it changed the behavior to wait the `probeInterval` first and then do the probe. This PR restores the previous behavior by running the probe first because it is causing issues when trying to start some of the sidecars (https://github.com/kubernetes-csi/external-attacher/pull/561). And in general, it slows down the startup of the sidecars by at least 1s, even when the plugin is already ready to accept connections.
Based on https://stackoverflow.com/a/54752803.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Restored the previous behavior of `ProbeForever` to do a probe first before sleeping.
```
