### PR TITLE
Let CSIMetricsManager serve additional registries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.23.1
 
 require (
 	github.com/container-storage-interface/spec v1.11.0
+	github.com/prometheus/client_golang v1.20.5
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.58.0
 	go.opentelemetry.io/otel/trace v1.33.0
@@ -43,7 +44,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.20.5 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.61.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

`csi-lib-utils` consumers may want to add additional metrics registries, but cannot currently use CSIMetricsManager (CMM) to serve them. 

For example, cluster operators have requested that the Kubernetes legacymetrics added to the provisioner sidecar in kubernetes-csi/external-provisioner#579 would also be added to other sidecars. Lets refactor `csi-lib-utils` to allow for additional registries instead of having this custom logic in each sidecar.

This PR adds method WithAdditionalRegistry to CMM, which lets the consumer give CMM additional registries to serve. 

Please see https://github.com/AndrewSirenko/kubernetes-csi-legacy-metrics/pull/1 to see how this PR would affect the sidecars where we want to add extra metrics. 

Alternatively we can add the legacymetrics by default in CMM to grant consumers process and Go runtime metrics, but this forces every consumer to take on legacymetrics dependency. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # N/A

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Let CSIMetricsManager serve additional registries through WithAdditionalRegistry
```
