### PR TITLE
Add releaseOnCancel to the leader election configuration

### DIFF
--- a/leaderelection/leader_election.go
+++ b/leaderelection/leader_election.go
@@ -40,6 +40,8 @@ const (
 	defaultRenewDeadline = 10 * time.Second
 	defaultRetryPeriod   = 5 * time.Second
 
+	defaultReleaseOnCancel = true
+
 	DefaultHealthCheckTimeout = 20 * time.Second
 
 	// HealthCheckerAddress is the address at which the leader election health
@@ -66,6 +68,8 @@ type leaderElection struct {
 	// within a timeout period.
 	healthCheck *leaderelection.HealthzAdaptor
 
+	releaseOnCancel bool
+
 	leaseDuration time.Duration
 	renewDeadline time.Duration
 	retryPeriod   time.Duration
@@ -83,13 +87,14 @@ func NewLeaderElection(clientset kubernetes.Interface, lockName string, runFunc 
 // NewLeaderElectionWithLeases returns an implementation of leader election using Leases
 func NewLeaderElectionWithLeases(clientset kubernetes.Interface, lockName string, runFunc func(ctx context.Context)) *leaderElection {
 	return &leaderElection{
-		runFunc:       runFunc,
-		lockName:      lockName,
-		resourceLock:  resourcelock.LeasesResourceLock,
-		leaseDuration: defaultLeaseDuration,
-		renewDeadline: defaultRenewDeadline,
-		retryPeriod:   defaultRetryPeriod,
-		clientset:     clientset,
+		runFunc:         runFunc,
+		lockName:        lockName,
+		resourceLock:    resourcelock.LeasesResourceLock,
+		leaseDuration:   defaultLeaseDuration,
+		renewDeadline:   defaultRenewDeadline,
+		releaseOnCancel: defaultReleaseOnCancel,
+		retryPeriod:     defaultRetryPeriod,
+		clientset:       clientset,
 	}
 }
 
@@ -111,6 +116,10 @@ func (l *leaderElection) WithRenewDeadline(renewDeadline time.Duration) {
 
 func (l *leaderElection) WithRetryPeriod(retryPeriod time.Duration) {
 	l.retryPeriod = retryPeriod
+}
+
+func (l *leaderElection) WithReleaseOnCancel(releaseOnCancel bool) {
+	l.releaseOnCancel = releaseOnCancel
 }
 
 // WithContext Add context
@@ -174,10 +183,11 @@ func (l *leaderElection) Run() error {
 	}
 
 	leaderConfig := leaderelection.LeaderElectionConfig{
-		Lock:          lock,
-		LeaseDuration: l.leaseDuration,
-		RenewDeadline: l.renewDeadline,
-		RetryPeriod:   l.retryPeriod,
+		Lock:            lock,
+		LeaseDuration:   l.leaseDuration,
+		RenewDeadline:   l.renewDeadline,
+		RetryPeriod:     l.retryPeriod,
+		ReleaseOnCancel: l.releaseOnCancel,
 		Callbacks: leaderelection.LeaderCallbacks{
 			OnStartedLeading: func(ctx context.Context) {
 				logger := klog.FromContext(ctx)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR adds ReleaseOnCancel to the configuration of NewLeaderElectionWithLeases. We need this to help with solving sidecars issue tracked in External Attacher [here](https://github.com/kubernetes-csi/external-attacher/issues/609) - we should have the ReleaseOnCancel turned on when releasing leases on sigterm. [This commit](https://github.com/kubernetes-csi/external-attacher/commit/529903466fdcbd883a72accdce431e54038fb4ae) shows how this will be implemented in the sidecars, but firstly this PR has to merge.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
