### PR TITLE
fix: instantiate labels map to never be nil

### DIFF
--- a/standardflags/flags.go
+++ b/standardflags/flags.go
@@ -44,7 +44,7 @@ type SidecarConfiguration struct {
 	MetricsPath    string
 }
 
-var Configuration = SidecarConfiguration{}
+var Configuration = SidecarConfiguration{LeaderElectionLabels: make(stringMap)}
 
 func RegisterCommonFlags(flags *flag.FlagSet) {
 	flags.BoolVar(&Configuration.ShowVersion, "version", false, "Show version.")


### PR DESCRIPTION
**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:

Fixes a panic from a nil map:

```
$ csi-attacher -leader-election-labels my-label:my-value,my-second-label:my-second-value
panic: assignment to entry in nil map

goroutine 1 [running]:
github.com/kubernetes-csi/csi-lib-utils/standardflags.(*stringMap).Set(0x40cf980?, {0x7fffbb22193c?, 0x7fffbb221925?})
	/home/jsafrane/project/go/src/github.com/kubernetes-csi/external-attacher/vendor/github.com/kubernetes-csi/csi-lib-utils/standardflags/flags.go:80 +0xd5
flag.(*FlagSet).parseOne(0xc0001b8000)
	/home/jsafrane/project/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.5.linux-amd64/src/flag/flag.go:1138 +0x619
flag.(*FlagSet).Parse(0xc0001b8000, {0xc000050250?, 0xc0001b8000?, 0x2735b36?})
	/home/jsafrane/project/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.5.linux-amd64/src/flag/flag.go:1157 +0x4a
flag.Parse(...)
	/home/jsafrane/project/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.5.linux-amd64/src/flag/flag.go:1188
main.main()
	/home/jsafrane/project/go/src/github.com/kubernetes-csi/external-attacher/cmd/csi-attacher/main.go:98 +0x17b
```


**Special notes for your reviewer**:

https://kubernetes.slack.com/archives/C8EJ01Z46/p1769596284565269?thread_ts=1763656931.426359&cid=C8EJ01Z46


-->
```release-note
Fixed crash when parsing cmdline option --leader-election-labels`.
```
